### PR TITLE
Added extra functionality to Database class

### DIFF
--- a/includes/classes/Database.class.php
+++ b/includes/classes/Database.class.php
@@ -186,6 +186,26 @@ class Database
 		$res = $stmt->fetch(PDO::FETCH_ASSOC);
 		return ($field === false || is_null($res)) ? $res : $res[$field];
 	}
+	
+	public function lists($table, $column, $key = null)
+	{
+		$selects = implode(', ', is_null($key) ? [$column] : [$column, $key]);
+		
+		$qry = "SELECT {$selects} FROM %%{$table}%%;";
+		$stmt = $this->_query($qry, [], 'select');
+
+		if (is_null($key)) {
+			while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+				$results[] = $row[$column];
+			}
+		} else {
+			while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+				$results[$row[$key]] = $row[$column];
+			}
+		}
+
+		return @$results;
+	}
 
 	public function query($qry)
 	{

--- a/includes/classes/Database.class.php
+++ b/includes/classes/Database.class.php
@@ -187,24 +187,40 @@ class Database
 		return ($field === false || is_null($res)) ? $res : $res[$field];
 	}
 	
+	/**
+	 * Lists column values of a table
+	 * with desired key from the
+	 * database as an array.
+	 *
+	 * @param  string 		$table
+	 * @param  string 		$column
+	 * @param  string|null 	$key
+	 * @return array
+	 */
 	public function lists($table, $column, $key = null)
 	{
 		$selects = implode(', ', is_null($key) ? [$column] : [$column, $key]);
 		
 		$qry = "SELECT {$selects} FROM %%{$table}%%;";
-		$stmt = $this->_query($qry, [], 'select');
+		$stmt = $this->_query($qry, array(), 'select');
 
-		if (is_null($key)) {
-			while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+		$results = [];
+		if (is_null($key))
+		{
+			while ($row = $stmt->fetch(PDO::FETCH_ASSOC))
+			{
 				$results[] = $row[$column];
 			}
-		} else {
-			while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+		}
+		else
+		{
+			while ($row = $stmt->fetch(PDO::FETCH_ASSOC))
+			{
 				$results[$row[$key]] = $row[$column];
 			}
 		}
 
-		return @$results;
+		return $results;
 	}
 
 	public function query($qry)


### PR DESCRIPTION
This way you can simply call `lists` method to get all the rows from a specific columns of a table.
```php
$results = Database::get()->lists('CRONJOBS', 'class');
```
As a result you retrieve this:
```php
array (size=8)
  0 => string 'ReferralCronjob' (length=15)
  1 => string 'StatisticCronjob' (length=16)
  2 => string 'DailyCronjob' (length=12)
  3 => string 'CleanerCronjob' (length=14)
  ...
```

If needed you can also specify the key of the results array.
```php
$results = Database::get()->lists('CRONJOBS', 'class', 'name');
```
As a result you retrieve this:
```php
array (size=8)
  'referral' => string 'ReferralCronjob' (length=15)
  'statistic' => string 'StatisticCronjob' (length=16)
  'daily' => string 'DailyCronjob' (length=12)
  'cleaner' => string 'CleanerCronjob' (length=14)
  ...
```