### PR TITLE
Update class.FlyingFleetsTable.php

### DIFF
--- a/includes/classes/class.FlyingFleetsTable.php
+++ b/includes/classes/class.FlyingFleetsTable.php
@@ -111,7 +111,10 @@ class FlyingFleetsTable
 				
 			if ($fleetRow['fleet_end_stay'] != $fleetRow['fleet_start_time'] && $fleetRow['fleet_end_stay'] > TIMESTAMP && ($this->IsPhalanx && $fleetRow['fleet_end_id'] == $this->planetId))
 				$FleetData[$fleetRow['fleet_end_stay'].$fleetRow['fleet_id']] = $this->BuildFleetEventTable($fleetRow, 2);
-		
+			
+			if ($fleetRow['fleet_end_stay'] > TIMESTAMP)
+				$FleetData[$fleetRow['fleet_end_stay'].$fleetRow['fleet_id']] = $this->BuildFleetEventTable($fleetRow, 2);
+				
 			if ($fleetRow['fleet_owner'] != $this->userId)
 				continue;
 		


### PR DESCRIPTION
Allow attacker to see the state 2 of the mission acs defend
- One of your Fleets from Planet Semirot [1:1:1] reached the Planet Planet [1:1:2]. Mission: ACS Defend 
- One of your Fleets from Planet Semirot [1:1:1] are in orbit around Planet Planet [1:1:2]. Mission: ACS Defend 
- One of your Fleets returns from Planet Planet [1:1:2] back to Planet Semirot [1:1:1]. Mission: ACS Defend 

and allow defender to see first state 0 and then state 2
- A friendly Fleets from player xterium [PM] from Planet Semirot [1:1:1] reached the Planet Planet [1:1:2]. Mission: ACS Defend 
- A friendly Fleets from player xterium [PM] from Planet Semirot [1:1:1] is in Orbit of the Planet Planet [1:1:2]. Mission: ACS Defend