### PR TITLE
Update ShowShipyardPage.class.php

### DIFF
--- a/includes/pages/game/ShowShipyardPage.class.php
+++ b/includes/pages/game/ShowShipyardPage.class.php
@@ -175,7 +175,6 @@ class ShowShipyardPage extends AbstractGamePage
 				}
 
 				$this->BuildAuftr($buildTodo);
-				$ElementQueue 	= unserialize($PLANET['b_hangar_id']);
 			}
 					
 			if ($action == "delete")
@@ -185,6 +184,7 @@ class ShowShipyardPage extends AbstractGamePage
 		}
 		
 		$elementInQueue	= array();
+		$ElementQueue 	= unserialize($PLANET['b_hangar_id']);
 		$buildList		= array();
 		$elementList	= array();
 


### PR DESCRIPTION
Wenn man die Bauschleife der Schiffe/deff löscht, verschwinden die auch erst nach neu laden der Seite.

So verschwinden sie gleich, ohne dass man die Seite neu laden muss, und das führt dann auch zu keinen weiteren Irritation.