### PR TITLE
Column names cannot be replaced by parameters in PDO

### DIFF
--- a/includes/pages/game/ShowInformationPage.class.php
+++ b/includes/pages/game/ShowInformationPage.class.php
@@ -178,9 +178,8 @@ class ShowInformationPage extends AbstractGamePage
 				break;
 		}
 
-		$sql = "SELECT id, name, galaxy, system, planet, last_jump_time, :resource43Name FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND planet_type = '3' AND ".$resource[43]." > 0 ORDER BY :order;";
+		$sql = "SELECT id, name, galaxy, system, planet, last_jump_time, ".$resource[43]." FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND planet_type = '3' AND ".$resource[43]." > 0 ORDER BY :order;";
 		$moonResult = $db->select($sql, array(
-			':resource43Name'   => $resource[43],
 			':planetID'         => $PLANET['id'],
 			':userID'           => $USER['id'],
 			':order'            => $OrderBy

--- a/includes/pages/game/ShowInformationPage.class.php
+++ b/includes/pages/game/ShowInformationPage.class.php
@@ -178,7 +178,7 @@ class ShowInformationPage extends AbstractGamePage
 				break;
 		}
 
-		$sql = "SELECT id, name, galaxy, system, planet, last_jump_time, :resource43Name FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND planet_type = '3' AND :resource43Name > 0 ORDER BY :order;";
+		$sql = "SELECT id, name, galaxy, system, planet, last_jump_time, :resource43Name FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND planet_type = '3' AND ".$resource[43]." > 0 ORDER BY :order;";
 		$moonResult = $db->select($sql, array(
 			':resource43Name'   => $resource[43],
 			':planetID'         => $PLANET['id'],


### PR DESCRIPTION
$moonList always returns an empty array, even when the users has two moons with jumpgates

https://secure.php.net/manual/en/pdo.prepare.php#111977