### PR TITLE
Buildings / Research costing +1 level

### DIFF
--- a/includes/classes/class.BuildFunctions.php
+++ b/includes/classes/class.BuildFunctions.php
@@ -67,8 +67,6 @@ class BuildFunctions
 
         if (in_array($Element, $reslist['fleet']) || in_array($Element, $reslist['defense']) || in_array($Element, $reslist['missile'])) {
             $elementLevel = $forLevel;
-        } elseif (isset($forLevel)) {
-            $elementLevel = $forLevel;
         } elseif (isset($PLANET[$resource[$Element]])) {
             $elementLevel = $PLANET[$resource[$Element]];
         } elseif (isset($USER[$resource[$Element]])) {


### PR DESCRIPTION
$elementLevel will never be set to either $PLANET[$resource[$Element]] or $USER[$resource[$Element]] therefore the cost displayed and taken from the planet will always be +1 level even when the Building / Research doesn't already exist on the planet.
Eg. Jumpgate
Factor is set to 2.00 in vars table
M 2000000, C 4000000, D 2000000 is the level one cost
although without the patch the current level one cost is:
M 4000000, C 8000000, D 4000000